### PR TITLE
Return early if the target row element doesn't exist

### DIFF
--- a/Our.Umbraco.WysiwygGrid/App_Plugins/Our.Umbraco.WysiwygGrid/Grid/grid-classes.js
+++ b/Our.Umbraco.WysiwygGrid/App_Plugins/Our.Umbraco.WysiwygGrid/Grid/grid-classes.js
@@ -60,6 +60,9 @@
                     var rowElements = areaElements[ai].getElementsByClassName("umb-row-inner");
                     area.rows.forEach(function (row, ri) {
                         var rowElement = rowElements[ri];
+                        if (rowElement === undefined)
+                        return;
+
                         addClasses(rowElement, row);
                         addStyles(rowElement, row);
 


### PR DESCRIPTION
Fix for issue #1 

At the point that `grid.initialized` fires there isn't always a 1:1 between rows and `umb-row-inner` so the safest thing to do is just check if the element exists and, if not, just do nothing.